### PR TITLE
Create new object instead of modify

### DIFF
--- a/plugins/module_utils/intersight.py
+++ b/plugins/module_utils/intersight.py
@@ -182,11 +182,10 @@ class IntersightModule():
         :param options: options dict with method and other params for API call
         :return: json http response object
         """
-
         try:
             response, info = self.intersight_call(**options)
             if not re.match(r'2..', str(info['status'])):
-                raise RuntimeError(info['status'], info['msg'], info['body'])
+                raise RuntimeError(info['status'], info['msg'], info.get('body',''))
         except Exception as e:
             self.module.fail_json(msg="API error: %s " % str(e))
 

--- a/plugins/modules/intersight_rest_api.py
+++ b/plugins/modules/intersight_rest_api.py
@@ -192,7 +192,6 @@ def compare_values(expected, actual):
 
 
 def configure_resource(intersight, moid):
-    
     if not intersight.module.check_mode:
         if moid and intersight.module.params['update_method'] != 'post':
             # update the resource - user has to specify all the props they want updated
@@ -202,7 +201,6 @@ def configure_resource(intersight, moid):
                 'body': intersight.module.params['api_body'],
                 'moid': moid,
             }
-
             response_dict = intersight.call_api(**options)
             if response_dict.get('Results'):
                 # return the 1st element in the results list
@@ -280,6 +278,7 @@ def main():
             resource_values_match = compare_values(module.params['api_body'], intersight.result['api_response'])
         else:  # request_delete
             delete_resource(intersight, moid)
+            
     if request_config and not resource_values_match:
         configure_resource(intersight, moid)
 

--- a/plugins/modules/intersight_rest_api.py
+++ b/plugins/modules/intersight_rest_api.py
@@ -146,6 +146,10 @@ def get_resource(intersight):
         'resource_path': intersight.module.params['resource_path'],
         'query_params': intersight.module.params['query_params'],
     }
+    if intersight.module.params["api_body"].get("Name") is not None:
+      # filter values by name if there is any name in the api_body
+      target_name = intersight.module.params["api_body"]["Name"]
+      options["query_params"] = {"$filter": "Name eq '{0}'".format(target_name)}
     response = intersight.call_api(**options)
     if response.get('Results'):
         if intersight.module.params['return_list']:
@@ -188,6 +192,7 @@ def compare_values(expected, actual):
 
 
 def configure_resource(intersight, moid):
+    
     if not intersight.module.check_mode:
         if moid and intersight.module.params['update_method'] != 'post':
             # update the resource - user has to specify all the props they want updated
@@ -197,6 +202,7 @@ def configure_resource(intersight, moid):
                 'body': intersight.module.params['api_body'],
                 'moid': moid,
             }
+
             response_dict = intersight.call_api(**options)
             if response_dict.get('Results'):
                 # return the 1st element in the results list
@@ -274,7 +280,6 @@ def main():
             resource_values_match = compare_values(module.params['api_body'], intersight.result['api_response'])
         else:  # request_delete
             delete_resource(intersight, moid)
-
     if request_config and not resource_values_match:
         configure_resource(intersight, moid)
 


### PR DESCRIPTION
This Pull requests contains 1 small bug fix and 1 change
bug fix: 
intersight.py line #188
Some error do not return anybody, thus resulting in a KeyError instead of a RuntimeError.

change: 
intersight_rest_api.oy line #149 ff
in my opinion 2 tasks with a different "name" in the "api_body" should create 2 objects ( currently objects are overwriten, regardless of the api_body ) 
I changed the behavior to only overwrite an object if there's already an object existing with the name equals to the name in the "api_body"